### PR TITLE
Add Playwright MCP server configuration and local settings gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/settings.local.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds configuration for the Playwright Model Context Protocol (MCP) server and updates the gitignore to exclude local Claude settings.

## Key Changes
- Added `.mcp.json` configuration file that registers the Playwright MCP server, enabling integration with the `@playwright/mcp` package via npx
- Added `.gitignore` entry to exclude `.claude/settings.local.json` from version control, preventing local user settings from being committed

## Implementation Details
The Playwright MCP server is configured to run via `npx -y @playwright/mcp@latest`, which allows Claude to interact with Playwright for browser automation tasks. The local settings exclusion ensures that user-specific Claude configurations remain private and don't pollute the repository.

https://claude.ai/code/session_01S2HKpTNFssBRAYbKj6f1vu